### PR TITLE
docs: 상위 엔티티 (CommonEntity, DateColumnEntity 등)의 프로퍼티에 swagger api 설명 추가

### DIFF
--- a/src/entities/common/common.entity.ts
+++ b/src/entities/common/common.entity.ts
@@ -1,7 +1,13 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { PrimaryGeneratedColumn } from "typeorm";
 import { DateColumnEntity } from "./date-column.entity";
 
 export class CommonEntity extends DateColumnEntity {
     @PrimaryGeneratedColumn()
+    @ApiProperty({
+        example: "12",
+        description: "데이터베이스의 테이블에서 갖는 객체의 식별값",
+        readOnly: true,
+    })
     id: number;
 }

--- a/src/entities/common/created-date-column.entity.ts
+++ b/src/entities/common/created-date-column.entity.ts
@@ -1,6 +1,13 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { BaseEntity, CreateDateColumn } from "typeorm";
 
 export class CreatedDateColumnEntity extends BaseEntity {
     @CreateDateColumn()
+    @ApiProperty({
+        example: "2022-12-31T08:48:40.042Z",
+        description:
+            "객체가 생성된 시간. 프런트의 객체 생성 요청에 따라 백엔드에서 기입한다.",
+        readOnly: true,
+    })
     createdAt: Date;
 }

--- a/src/entities/common/date-column.entity.ts
+++ b/src/entities/common/date-column.entity.ts
@@ -1,10 +1,23 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { DeleteDateColumn, UpdateDateColumn } from "typeorm";
 import { CreatedDateColumnEntity } from "./created-date-column.entity";
 
 export class DateColumnEntity extends CreatedDateColumnEntity {
     @UpdateDateColumn()
+    @ApiProperty({
+        example: "2022-12-30T08:48:40.042Z",
+        description:
+            "객체가 수정된 시간. 프런트의 객체 생성 또는 수정 요청에 따라 백엔드에서 자동으로 갱신한다. 수정되지 않았다면 생성 시간과 동일하다.",
+        readOnly: true,
+    })
     updatedAt: Date;
 
     @DeleteDateColumn()
+    @ApiProperty({
+        example: null,
+        description:
+            "객체가 삭제된 시간. 프런트의 객체 삭제 요청에 따라 백엔드에서 기입한다. 삭제되지 않은 객체라면, null값을 갖는다.",
+        readOnly: true,
+    })
     deletedAt: Date;
 }


### PR DESCRIPTION
엔티티의 각 프로퍼티에Swagger Api Docs에 들어갈 설명 및 예제 추가