### PR TITLE
Product에 연관된 엔티티 정의

### DIFF
--- a/src/entities/brand.entity.ts
+++ b/src/entities/brand.entity.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmptyString } from "src/decorators/is-not-empty-string.decorator";
+import { Column, Entity, OneToMany } from "typeorm";
+import { CommonEntity } from "./common/common.entity";
+import { ProductEntity } from "./product.entity";
+
+@Entity()
+export class BrandEntity extends CommonEntity {
+    @ApiProperty({
+        description: "브랜드명",
+        examples: ["게스(GUESS)", "구찌(GUCCI)"],
+    })
+    @IsNotEmptyString()
+    @Column()
+    name: string;
+
+    /**
+     * below are relations
+     */
+
+    @OneToMany(() => ProductEntity, (product) => product.brand)
+    products: ProductEntity[];
+}

--- a/src/entities/category.entity.ts
+++ b/src/entities/category.entity.ts
@@ -1,14 +1,41 @@
-import { Entity, Column, OneToMany } from "typeorm";
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmptyString } from "src/decorators/is-not-empty-string.decorator";
+import { IsOptionalNumber } from "src/decorators/is-optional-number.decorator";
+import { Entity, Column, OneToMany, ManyToOne, JoinColumn } from "typeorm";
 import { CommonEntity } from "./common/common.entity";
 import { ProductEntity } from "./product.entity";
 
 @Entity()
 export class CategoryEntity extends CommonEntity {
+    @ApiProperty({
+        description: "카테고리 명",
+        examples: ["아우터", "상의", "하의", "코트", "청바지", "맨투맨"],
+    })
+    @IsNotEmptyString()
     @Column()
     name: string;
 
+    @ApiProperty({
+        description:
+            "상위 카테고리 id. null값을 갖는 경우에는 상위 카테고리를 의미하고, 값을 가지면 하위 카테고리를 의미한다. 현재 카테고리는 상/하위 2단계로만 구분하고, 하위 카테고리를 이 프로퍼티에 지정하지 않는다.",
+        examples: [3, null],
+    })
+    @IsOptionalNumber()
+    @Column()
+    parentId: number;
+
     /**
-     * below are relations
+     * below are self-relations
+     */
+    @ManyToOne(() => CategoryEntity, (c) => c.children)
+    @JoinColumn({ name: "parentId", referencedColumnName: "id" })
+    parent: CategoryEntity;
+
+    @OneToMany(() => CategoryEntity, (c) => c.parent, { lazy: true })
+    children: CategoryEntity[];
+
+    /**
+     * below are outer-relations
      */
 
     @OneToMany(() => ProductEntity, (p) => p.category)

--- a/src/entities/common/created-date-only-common.entity.ts
+++ b/src/entities/common/created-date-only-common.entity.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { PrimaryGeneratedColumn } from "typeorm";
+import { CreatedDateColumnEntity } from "./created-date-column.entity";
+
+export class CreatedDateOnlyCommonEntity extends CreatedDateColumnEntity {
+    @PrimaryGeneratedColumn()
+    @ApiProperty({
+        example: "12",
+        description: "데이터베이스의 테이블에서 갖는 객체의 식별값",
+        readOnly: true,
+    })
+    id: number;
+}

--- a/src/entities/product-image.entity.ts
+++ b/src/entities/product-image.entity.ts
@@ -1,3 +1,5 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsUrl } from "class-validator";
 import { Entity, Column, ManyToOne, JoinColumn } from "typeorm";
 import { CommonEntity } from "./common/common.entity";
 import { ProductEntity } from "./product.entity";
@@ -12,12 +14,26 @@ export type ImageType = keyof typeof ImageType;
 
 @Entity()
 export class ProductImageEntity extends CommonEntity {
-    @Column()
+    @ApiProperty({
+        description: "어떠한 상품에 대한 이미지인지 알려주는 상품의 id값",
+        example: 4,
+    })
+    @Column({ name: "productId" })
     productId: number;
 
+    @ApiProperty({
+        description: "어떠한 상품에 대한 이미지인지 알려주는 상품의 id값",
+        examples: ["Main", "Sub", "Thumbnail"],
+    })
+    @IsNotEmpty()
     @Column()
     imageType: ImageType;
 
+    @ApiProperty({
+        description: "상품이 저장된 AWS S3 url path",
+        example: "https://vinzip.kr/web/product/big//38/A7164.jpg",
+    })
+    @IsUrl()
     @Column()
     url: string;
 
@@ -25,7 +41,7 @@ export class ProductImageEntity extends CommonEntity {
      * below are relations
      */
 
-    @ManyToOne(() => ProductEntity, (p) => p.images)
+    @ManyToOne(() => ProductEntity, (product) => product.images)
     @JoinColumn({ name: "productId", referencedColumnName: "id" })
     product: ProductEntity;
 }

--- a/src/entities/product-option-price.entity.ts
+++ b/src/entities/product-option-price.entity.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsPositive } from "class-validator";
+import { IsNotEmptyNumber } from "src/decorators/is-not-empty-number.decorator";
+import { Column, Entity, JoinColumn, ManyToOne } from "typeorm";
+import { CommonEntity } from "./common/common.entity";
+import { CreatedDateOnlyCommonEntity } from "./common/created-date-only-common.entity";
+import { ProductOptionEntity } from "./product-option.entity";
+
+@Entity()
+export class ProductOptionPriceEntity extends CreatedDateOnlyCommonEntity {
+    @ApiProperty({
+        description: "이 레코드의 생성일시(datetime)부터의 판매가",
+        example: 50_000,
+    })
+    @IsNotEmptyNumber()
+    @IsPositive()
+    @Column()
+    salePrice: number;
+
+    @ApiProperty({
+        description: "상품 판매 옵션의 id값",
+        example: 12,
+    })
+    @IsNotEmptyNumber()
+    @Column()
+    productOptionId: number;
+
+    /**
+     * below are relations
+     */
+
+    @ManyToOne(
+        () => ProductOptionEntity,
+        (productOption) => productOption.prices
+    )
+    @JoinColumn({ name: "productId", referencedColumnName: "id" })
+    product: ProductOptionEntity;
+}

--- a/src/entities/product-option.entity.ts
+++ b/src/entities/product-option.entity.ts
@@ -1,23 +1,37 @@
-import { Entity, Column, ManyToOne, JoinColumn } from "typeorm";
+import { ApiProperty } from "@nestjs/swagger";
+import { IsPositive } from "class-validator";
+import { IsNotEmptyNumber } from "src/decorators/is-not-empty-number.decorator";
+import { IsNotEmptyString } from "src/decorators/is-not-empty-string.decorator";
+import { Entity, Column, ManyToOne, JoinColumn, OneToMany } from "typeorm";
 import { CommonEntity } from "./common/common.entity";
+import { ProductOptionPriceEntity } from "./product-option-price.entity";
 import { ProductEntity } from "./product.entity";
 
 @Entity()
 export class ProductOptionEntity extends CommonEntity {
-    @Column()
+    @ApiProperty({
+        description: "상품의 id값",
+        example: "2",
+    })
+    @Column({ name: "productId" })
     productId: number;
 
+    @ApiProperty({
+        description: "상품에 대한 옵션",
+        example: "빨간색 남성용 XL사이즈",
+    })
+    @IsNotEmptyString()
     @Column()
     name: string;
-
-    @Column()
-    salePrice: number;
 
     /**
      * below are relations
      */
 
-    @ManyToOne(() => ProductEntity, (p) => p.options)
+    @ManyToOne(() => ProductEntity, (product) => product.options)
     @JoinColumn({ name: "productId", referencedColumnName: "id" })
     product: ProductEntity;
+
+    @OneToMany(() => ProductOptionPriceEntity, (pop) => pop.salePrice)
+    prices: ProductOptionPriceEntity[];
 }

--- a/src/entities/product.entity.ts
+++ b/src/entities/product.entity.ts
@@ -1,4 +1,8 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmptyNumber } from "src/decorators/is-not-empty-number.decorator";
+import { IsNotEmptyString } from "src/decorators/is-not-empty-string.decorator";
 import { Entity, Column, ManyToOne, JoinColumn, OneToMany } from "typeorm";
+import { BrandEntity } from "./brand.entity";
 import { CategoryEntity } from "./category.entity";
 import { CommonEntity } from "./common/common.entity";
 import { ProductImageEntity } from "./product-image.entity";
@@ -7,26 +11,53 @@ import { SellerEntity } from "./seller.entity";
 
 @Entity()
 export class ProductEntity extends CommonEntity {
+    @ApiProperty({
+        description: "상품명",
+        example: "울 혼방 체크 패턴 배색 엘보 패치 차이나넥 자켓",
+    })
+    @IsNotEmptyString()
     @Column()
     name: string;
 
+    @ApiProperty({
+        description: "카테고리 id값",
+        example: 3,
+    })
+    @IsNotEmptyNumber()
     @Column()
     categoryId: number;
 
+    @ApiProperty({
+        description: "판매자 id값",
+        example: 2,
+    })
+    @IsNotEmptyNumber()
     @Column()
     sellerId: number;
+
+    @ApiProperty({
+        description: "브랜드 id값",
+        example: 4,
+    })
+    @IsNotEmptyNumber()
+    @Column()
+    brandId: number;
 
     /**
      * below are relations
      */
 
-    @ManyToOne(() => CategoryEntity, (c) => c.products)
+    @ManyToOne(() => CategoryEntity, (category) => category.products)
     @JoinColumn({ name: "categoryId", referencedColumnName: "id" })
     category: CategoryEntity;
 
-    @ManyToOne(() => SellerEntity, (s) => s.products)
+    @ManyToOne(() => SellerEntity, (seller) => seller.products)
     @JoinColumn({ name: "sellerId", referencedColumnName: "id" })
     seller: SellerEntity;
+
+    @ManyToOne(() => BrandEntity, (brand) => brand.products)
+    @JoinColumn({ name: "brandId", referencedColumnName: "id" })
+    brand: BrandEntity;
 
     @OneToMany(() => ProductOptionEntity, (po) => po.product)
     options: ProductOptionEntity[];

--- a/src/entities/seller.entity.ts
+++ b/src/entities/seller.entity.ts
@@ -1,33 +1,44 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { IsNotEmptyString } from "../decorators/is-not-empty-string.decorator";
 import { IsOptionalString } from "../decorators/is-optional-string.decorator";
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from "typeorm";
+import { Entity, Column, OneToMany } from "typeorm";
 import { CommonEntity } from "./common/common.entity";
 import { ProductEntity } from "./product.entity";
+import { Matches } from "class-validator";
+
+const brnRegExp = "^[0-9]{3}-[0-9]{2}-[0-9]{5}$";
 
 @Entity()
 export class SellerEntity extends CommonEntity {
-    @PrimaryGeneratedColumn()
-    id: number;
-
+    @ApiProperty({
+        description: "본 사이트에서 판매자가 사용할 닉네임",
+        example: "무신사",
+    })
     @IsNotEmptyString()
     @Column()
     name: string;
 
-    @ApiProperty({ description: "사업자 번호" })
+    @ApiProperty({
+        description: "사업자등록증에 명시된 사업자 번호",
+        example: "311-05-65481",
+    })
     @IsOptionalString()
-    @Column()
-    brn: string;
+    @Matches(brnRegExp)
+    @Column({ unique: true })
+    businessNumber: string;
 
-    @ApiProperty({ description: "사업자 번호" })
+    @ApiProperty({
+        description: "법인사업자의 경우 법인명/단체명, 개인사업자의 경우 상호",
+        example: "(주)무신사",
+    })
     @IsOptionalString()
     @Column()
-    brandName: string;
+    businessName: string;
 
     /**
      * below are relations
      */
 
-    @OneToMany(() => ProductEntity, (p) => p.seller)
+    @OneToMany(() => ProductEntity, (p) => p.seller, { lazy: true })
     products: ProductEntity[];
 }


### PR DESCRIPTION
## 변경사항
- brand, product-option-price가 추가되었습니다.
- product, product-image, product-option, seller, category, brand, product-option-price에 api 설명이 추가되었습니다.
- category에는 상위 카테고리 (부모 카테고리 id) 칼럼 추가
- seller에는 닉네임, 사업자등록번호, 사업자 명(법인명/상호)로 프로퍼티 변경


## 중점사항
- 연관관계가 적절한지 리뷰 부탁드립니다. (특히 category 엔티티의 self-join 부분)
- 프로퍼티에 대한 api 설명이 충분한지 확인 부탁드립니다.